### PR TITLE
Add setDeviceVersion()

### DIFF
--- a/Adafruit_USBD_Device.cpp
+++ b/Adafruit_USBD_Device.cpp
@@ -156,6 +156,11 @@ void Adafruit_USBD_Device::setVersion(uint16_t bcd)
   _desc_device.bcdUSB = bcd;
 }
 
+void Adafruit_USBD_Device::setDeviceVersion(uint16_t bcd)
+{
+  _desc_device.bcdDevice = bcd;
+}
+
 
 void Adafruit_USBD_Device::setLanguageDescriptor (uint16_t language_id)
 {

--- a/Adafruit_USBD_Device.h
+++ b/Adafruit_USBD_Device.h
@@ -60,6 +60,7 @@ class Adafruit_USBD_Device
 
     void setID(uint16_t vid, uint16_t pid);
     void setVersion(uint16_t bcd);
+    void setDeviceVersion(uint16_t bcd);
 
     void setLanguageDescriptor(uint16_t language_id);
     void setManufacturerDescriptor(const char *s);


### PR DESCRIPTION
Allow to set the product's version number.

This allows to export the Arduino sketch version number to the USB descriptor, it is shown in the user interface of the operating system, or in software using the device.