### PR TITLE
Add print:: write for CDC to make it compatible with Arduino USB stack.

### DIFF
--- a/Adafruit_USBD_CDC.h
+++ b/Adafruit_USBD_CDC.h
@@ -51,7 +51,9 @@ public:
 	size_t write(const char *buffer, size_t size) {
 	  return write((const uint8_t *)buffer, size);
 	}
+
 	virtual int availableForWrite(void);
+	using Print::write; // pull in write(str) from Print
 	operator bool();
 };
 


### PR DESCRIPTION
There are many libraries used ```Serial.write (uint8_t *)```; ```using Print::write``` can maintains consistency with Arduino's USB stack, so no other changes are required.