### PR TITLE
Added HID Gamepad hat support

### DIFF
--- a/tinyusb/src/class/hid/hid.h
+++ b/tinyusb/src/class/hid/hid.h
@@ -157,7 +157,7 @@ typedef struct TU_ATTR_PACKED
   int8_t  y;         /**< Current delta y   movement of the gamepad joystick 1. */
   int8_t  z;         /**< Current delta z   movement of the gamepad joystick 2. */
   int8_t  r_z;       /**< Current delta r_z movement of the gamepad joystick 2. */
-  uint16_t hat;       /**< buttons mask for currently pressed buttons in the gamepad hat */
+  uint8_t hat;      /**< buttons mask for currently pressed buttons in the gamepad hat */
 }hid_gamepad_report_t;
 
 /// Standard Gamepad Buttons Bitmap (from Linux input event codes)
@@ -178,7 +178,7 @@ typedef enum
   GAMEPAD_BUTTON_MODE   = TU_BIT(12), ///< Mode button
   GAMEPAD_BUTTON_THUMBL = TU_BIT(13), ///< L3 button
   GAMEPAD_BUTTON_THUMBR = TU_BIT(14), ///< R3 button
-  GAMEPAD_BUTTON_       = TU_BIT(15), ///< Undefined button
+//GAMEPAD_BUTTON_       = TU_BIT(15), ///< Undefined button
 }hid_gamepad_button_bm_t;
 
 /// Standard Gamepad HAT/DPAD Buttons Bitmap (from Linux input event codes)

--- a/tinyusb/src/class/hid/hid.h
+++ b/tinyusb/src/class/hid/hid.h
@@ -157,7 +157,7 @@ typedef struct TU_ATTR_PACKED
   int8_t  y;         /**< Current delta y   movement of the gamepad joystick 1. */
   int8_t  z;         /**< Current delta z   movement of the gamepad joystick 2. */
   int8_t  r_z;       /**< Current delta r_z movement of the gamepad joystick 2. */
-  uint8_t hat;       /**< buttons mask for currently pressed buttons in the gamepad hat */
+  uint16_t hat;       /**< buttons mask for currently pressed buttons in the gamepad hat */
 }hid_gamepad_report_t;
 
 /// Standard Gamepad Buttons Bitmap (from Linux input event codes)

--- a/tinyusb/src/class/hid/hid.h
+++ b/tinyusb/src/class/hid/hid.h
@@ -149,14 +149,15 @@ typedef enum
 /** \addtogroup ClassDriver_HID_Gamepad Gamepad
  *  @{ */
 
-/// Standard HID Boot Protocol Gampad Report.
+/// Standard HID Boot Protocol Gamepad Report.
 typedef struct TU_ATTR_PACKED
 {
-  uint16_t buttons; /**< buttons mask for currently pressed buttons in the gamepad. */
-  int8_t  x;        /**< Current delta x   movement of the gamepad joystick 1. */
-  int8_t  y;        /**< Current delta y   movement of the gamepad joystick 1. */
-  int8_t  z;        /**< Current delta z   movement of the gamepad joystick 2. */
-  int8_t  r_z;      /**< Current delta r_z movement of the gamepad joystick 2. */
+  uint16_t buttons;  /**< buttons mask for currently pressed buttons in the gamepad. */
+  int8_t  x;         /**< Current delta x   movement of the gamepad joystick 1. */
+  int8_t  y;         /**< Current delta y   movement of the gamepad joystick 1. */
+  int8_t  z;         /**< Current delta z   movement of the gamepad joystick 2. */
+  int8_t  r_z;       /**< Current delta r_z movement of the gamepad joystick 2. */
+  uint8_t hat;       /**< buttons mask for currently pressed buttons in the gamepad hat */
 }hid_gamepad_report_t;
 
 /// Standard Gamepad Buttons Bitmap (from Linux input event codes)
@@ -180,6 +181,20 @@ typedef enum
   GAMEPAD_BUTTON_       = TU_BIT(15), ///< Undefined button
 }hid_gamepad_button_bm_t;
 
+/// Standard Gamepad HAT/DPAD Buttons Bitmap (from Linux input event codes)
+typedef enum
+{
+  GAMEPAD_HAT_CENTERED   = 0,  ///< DPAD_CENTERED
+  GAMEPAD_HAT_UP         = 1,  ///< DPAD_UP
+  GAMEPAD_HAT_UP_RIGHT   = 2,  ///< DPAD_UP_RIGHT
+  GAMEPAD_HAT_RIGHT      = 3,  ///< DPAD_RIGHT
+  GAMEPAD_HAT_DOWN_RIGHT = 4,  ///< DPAD_DOWN_RIGHT
+  GAMEPAD_HAT_DOWN       = 5,  ///< DPAD_DOWN
+  GAMEPAD_HAT_DOWN_LEFT  = 6,  ///< DPAD_DOWN_LEFT
+  GAMEPAD_HAT_LEFT       = 7,  ///< DPAD_LEFT
+  GAMEPAD_HAT_UP_LEFT    = 8,  ///< DPAD_UP_LEFT
+}hid_gamepad_hat_bm_t;
+
 /// @}
 
 //--------------------------------------------------------------------+
@@ -196,7 +211,7 @@ typedef struct TU_ATTR_PACKED
   int8_t  y;       /**< Current delta y movement on the mouse. */
   int8_t  wheel;   /**< Current delta wheel movement on the mouse. */
   int8_t  pan;     // using AC Pan
-} hid_mouse_report_t;
+}hid_mouse_report_t;
 
 /// Standard Mouse Buttons Bitmap
 typedef enum

--- a/tinyusb/src/class/hid/hid.h
+++ b/tinyusb/src/class/hid/hid.h
@@ -149,17 +149,52 @@ typedef enum
 /** \addtogroup ClassDriver_HID_Gamepad Gamepad
  *  @{ */
 
+/* From https://www.kernel.org/doc/html/latest/input/gamepad.html
+          ____________________________              __
+         / [__ZL__]          [__ZR__] \               |
+        / [__ TL __]        [__ TR __] \              | Front Triggers
+     __/________________________________\__         __|
+    /                                  _   \          |
+   /      /\           __             (N)   \         |
+  /       ||      __  |MO|  __     _       _ \        | Main Pad
+ |    <===DP===> |SE|      |ST|   (W) -|- (E) |       |
+  \       ||    ___          ___       _     /        |
+  /\      \/   /   \        /   \     (S)   /\      __|
+ /  \________ | LS  | ____ |  RS | ________/  \       |
+|         /  \ \___/ /    \ \___/ /  \         |      | Control Sticks
+|        /    \_____/      \_____/    \        |    __|
+|       /                              \       |
+ \_____/                                \_____/
+
+     |________|______|    |______|___________|
+       D-Pad    Left       Right   Action Pad
+               Stick       Stick
+
+                 |_____________|
+                    Menu Pad
+
+  Most gamepads have the following features:
+  - Action-Pad 4 buttons in diamonds-shape (on the right side) NORTH, SOUTH, WEST and EAST.
+  - D-Pad (Direction-pad) 4 buttons (on the left side) that point up, down, left and right.
+  - Menu-Pad Different constellations, but most-times 2 buttons: SELECT - START.
+  - Analog-Sticks provide freely moveable sticks to control directions, Analog-sticks may also
+  provide a digital button if you press them.
+  - Triggers are located on the upper-side of the pad in vertical direction. The upper buttons
+  are normally named Left- and Right-Triggers, the lower buttons Z-Left and Z-Right.
+  - Rumble Many devices provide force-feedback features. But are mostly just simple rumble motors.
+ */
+
 /// HID Gamepad Protocol Report.
 typedef struct TU_ATTR_PACKED
 {
-  uint16_t buttons;  /**< buttons mask for currently pressed buttons in the gamepad. */
-  int8_t  x;         /**< Current delta x   movement of the gamepad left joystick. */
-  int8_t  y;         /**< Current delta y   movement of the gamepad left joystick. */
-  int8_t  z;         /**< Current delta z   movement of the gamepad right joystick. */
-  int8_t  rx;        /**< Current delta Rx  movement of the gamepad analog left trigger. */
-  int8_t  ry;        /**< Current delta Ry  movement of the gamepad analog right trigger. */
-  int8_t  rz;        /**< Current delta Rz  movement of the gamepad right joystick. */
-  uint8_t hat;       /**< buttons mask for currently pressed buttons in the gamepad hat */
+  int8_t  x;         ///< Delta x  movement of left analog-stick
+  int8_t  y;         ///< Delta y  movement of left analog-stick
+  int8_t  z;         ///< Delta z  movement of right analog-joystick
+  int8_t  rz;        ///< Delta Rz movement of right analog-joystick
+  int8_t  rx;        ///< Delta Rx movement of analog left trigger
+  int8_t  ry;        ///< Delta Ry movement of analog right trigger
+  uint8_t hat;       ///< Buttons mask for currently pressed buttons in the DPad/hat
+  uint16_t buttons;  ///< Buttons mask for currently pressed buttons
 }hid_gamepad_report_t;
 
 /// Standard Gamepad Buttons Bitmap (from Linux input event codes)

--- a/tinyusb/src/class/hid/hid.h
+++ b/tinyusb/src/class/hid/hid.h
@@ -144,6 +144,45 @@ typedef enum
 /** @} */
 
 //--------------------------------------------------------------------+
+// GAMEPAD
+//--------------------------------------------------------------------+
+/** \addtogroup ClassDriver_HID_Gamepad Gamepad
+ *  @{ */
+
+/// Standard HID Boot Protocol Gampad Report.
+typedef struct TU_ATTR_PACKED
+{
+  uint16_t buttons; /**< buttons mask for currently pressed buttons in the gamepad. */
+  int8_t  x;        /**< Current delta x   movement of the gamepad joystick 1. */
+  int8_t  y;        /**< Current delta y   movement of the gamepad joystick 1. */
+  int8_t  z;        /**< Current delta z   movement of the gamepad joystick 2. */
+  int8_t  r_z;      /**< Current delta r_z movement of the gamepad joystick 2. */
+}hid_gamepad_report_t;
+
+/// Standard Gamepad Buttons Bitmap (from Linux input event codes)
+typedef enum
+{
+  GAMEPAD_BUTTON_A      = TU_BIT(0),  ///< A/South button
+  GAMEPAD_BUTTON_B      = TU_BIT(1),  ///< B/East button
+  GAMEPAD_BUTTON_C      = TU_BIT(2),  ///< C button
+  GAMEPAD_BUTTON_X      = TU_BIT(3),  ///< X/North button
+  GAMEPAD_BUTTON_Y      = TU_BIT(4),  ///< Y/West button
+  GAMEPAD_BUTTON_Z      = TU_BIT(5),  ///< Z button
+  GAMEPAD_BUTTON_TL     = TU_BIT(6),  ///< L1 button
+  GAMEPAD_BUTTON_TR     = TU_BIT(7),  ///< R1 button
+  GAMEPAD_BUTTON_TL2    = TU_BIT(8),  ///< L2 button
+  GAMEPAD_BUTTON_TR2    = TU_BIT(9),  ///< R2 button
+  GAMEPAD_BUTTON_SELECT = TU_BIT(10), ///< Select button
+  GAMEPAD_BUTTON_START  = TU_BIT(11), ///< Start button
+  GAMEPAD_BUTTON_MODE   = TU_BIT(12), ///< Mode button
+  GAMEPAD_BUTTON_THUMBL = TU_BIT(13), ///< L3 button
+  GAMEPAD_BUTTON_THUMBR = TU_BIT(14), ///< R3 button
+  GAMEPAD_BUTTON_       = TU_BIT(15), ///< Undefined button
+}hid_gamepad_button_bm_t;
+
+/// @}
+
+//--------------------------------------------------------------------+
 // MOUSE
 //--------------------------------------------------------------------+
 /** \addtogroup ClassDriver_HID_Mouse Mouse

--- a/tinyusb/src/class/hid/hid.h
+++ b/tinyusb/src/class/hid/hid.h
@@ -149,15 +149,17 @@ typedef enum
 /** \addtogroup ClassDriver_HID_Gamepad Gamepad
  *  @{ */
 
-/// Standard HID Boot Protocol Gamepad Report.
+/// HID Gamepad Protocol Report.
 typedef struct TU_ATTR_PACKED
 {
   uint16_t buttons;  /**< buttons mask for currently pressed buttons in the gamepad. */
-  int8_t  x;         /**< Current delta x   movement of the gamepad joystick 1. */
-  int8_t  y;         /**< Current delta y   movement of the gamepad joystick 1. */
-  int8_t  z;         /**< Current delta z   movement of the gamepad joystick 2. */
-  int8_t  r_z;       /**< Current delta r_z movement of the gamepad joystick 2. */
-  uint8_t hat;      /**< buttons mask for currently pressed buttons in the gamepad hat */
+  int8_t  x;         /**< Current delta x   movement of the gamepad left joystick. */
+  int8_t  y;         /**< Current delta y   movement of the gamepad left joystick. */
+  int8_t  z;         /**< Current delta z   movement of the gamepad right joystick. */
+  int8_t  rx;        /**< Current delta Rx  movement of the gamepad analog left trigger. */
+  int8_t  ry;        /**< Current delta Ry  movement of the gamepad analog right trigger. */
+  int8_t  rz;        /**< Current delta Rz  movement of the gamepad right joystick. */
+  uint8_t hat;       /**< buttons mask for currently pressed buttons in the gamepad hat */
 }hid_gamepad_report_t;
 
 /// Standard Gamepad Buttons Bitmap (from Linux input event codes)

--- a/tinyusb/src/class/hid/hid.h
+++ b/tinyusb/src/class/hid/hid.h
@@ -152,14 +152,14 @@ typedef enum
 /// HID Gamepad Protocol Report.
 typedef struct TU_ATTR_PACKED
 {
-  uint16_t buttons;  /**< buttons mask for currently pressed buttons in the gamepad. */
   int8_t  x;         /**< Current delta x   movement of the gamepad left joystick. */
   int8_t  y;         /**< Current delta y   movement of the gamepad left joystick. */
   int8_t  z;         /**< Current delta z   movement of the gamepad right joystick. */
+  int8_t  rz;        /**< Current delta Rz  movement of the gamepad right joystick. */
   int8_t  rx;        /**< Current delta Rx  movement of the gamepad analog left trigger. */
   int8_t  ry;        /**< Current delta Ry  movement of the gamepad analog right trigger. */
-  int8_t  rz;        /**< Current delta Rz  movement of the gamepad right joystick. */
   uint8_t hat;       /**< buttons mask for currently pressed buttons in the gamepad hat */
+  uint16_t buttons;  /**< buttons mask for currently pressed buttons in the gamepad. */
 }hid_gamepad_report_t;
 
 /// Standard Gamepad Buttons Bitmap (from Linux input event codes)

--- a/tinyusb/src/class/hid/hid_device.h
+++ b/tinyusb/src/class/hid/hid_device.h
@@ -276,13 +276,13 @@ TU_ATTR_WEAK bool tud_hid_set_idle_cb(uint8_t idle_rate);
     HID_REPORT_COUNT ( 4                                      ) ,\
     HID_REPORT_SIZE  ( 8                                      ) ,\
     HID_INPUT        ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE ) ,\
-    /* 16 bit Hat Button Map  */ \
+    /* 8 bit Hat Button Map  */ \
     HID_USAGE_PAGE   ( HID_USAGE_PAGE_DESKTOP                 ) ,\
     HID_USAGE        ( HID_USAGE_DESKTOP_HAT_SWITCH           ) ,\
-    HID_LOGICAL_MIN  ( 1                                      ) ,\
+    HID_LOGICAL_MIN  ( 0                                      ) ,\
     HID_LOGICAL_MAX  ( 8                                      ) ,\
     HID_PHYSICAL_MIN ( 0                                      ) ,\
-    HID_PHYSICAL_MAX ( 315                                    ) ,\
+    HID_PHYSICAL_MAX_N ( 315, 2                               ) ,\
     HID_REPORT_COUNT ( 1                                      ) ,\
     HID_REPORT_SIZE  ( 8                                      ) ,\
     HID_INPUT        ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE ) ,\

--- a/tinyusb/src/class/hid/hid_device.h
+++ b/tinyusb/src/class/hid/hid_device.h
@@ -276,7 +276,7 @@ TU_ATTR_WEAK bool tud_hid_set_idle_cb(uint8_t idle_rate);
     HID_REPORT_COUNT ( 4                                      ) ,\
     HID_REPORT_SIZE  ( 8                                      ) ,\
     HID_INPUT        ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE ) ,\
-    /* 8 bit Hat Button Map  */ \
+    /* 16 bit Hat Button Map  */ \
     HID_USAGE_PAGE   ( HID_USAGE_PAGE_DESKTOP                 ) ,\
     HID_USAGE        ( HID_USAGE_DESKTOP_HAT_SWITCH           ) ,\
     HID_LOGICAL_MIN  ( 1                                      ) ,\

--- a/tinyusb/src/class/hid/hid_device.h
+++ b/tinyusb/src/class/hid/hid_device.h
@@ -256,23 +256,14 @@ TU_ATTR_WEAK bool tud_hid_set_idle_cb(uint8_t idle_rate);
   HID_COLLECTION ( HID_COLLECTION_APPLICATION )                 ,\
     /* Report ID if any */\
     __VA_ARGS__ \
-    /* 16 bit Button Map */ \
-    HID_USAGE_PAGE   ( HID_USAGE_PAGE_BUTTON                  ) ,\
-    HID_USAGE_MIN    ( 1                                      ) ,\
-    HID_USAGE_MAX    ( 16                                     ) ,\
-    HID_LOGICAL_MIN  ( 0                                      ) ,\
-    HID_LOGICAL_MAX  ( 1                                      ) ,\
-    HID_REPORT_COUNT ( 16                                     ) ,\
-    HID_REPORT_SIZE  ( 1                                      ) ,\
-    HID_INPUT        ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE ) ,\
-    /* 8 bit X, Y, Z, Rx, Ry, Rz (min -127, max 127 ) */ \
+    /* 8 bit X, Y, Z, Rz, Rx, Ry (min -127, max 127 ) */ \
     HID_USAGE_PAGE   ( HID_USAGE_PAGE_DESKTOP                 ) ,\
     HID_USAGE        ( HID_USAGE_DESKTOP_X                    ) ,\
     HID_USAGE        ( HID_USAGE_DESKTOP_Y                    ) ,\
     HID_USAGE        ( HID_USAGE_DESKTOP_Z                    ) ,\
+    HID_USAGE        ( HID_USAGE_DESKTOP_RZ                   ) ,\
     HID_USAGE        ( HID_USAGE_DESKTOP_RX                   ) ,\
     HID_USAGE        ( HID_USAGE_DESKTOP_RY                   ) ,\
-    HID_USAGE        ( HID_USAGE_DESKTOP_RZ                   ) ,\
     HID_LOGICAL_MIN  ( 0x81                                   ) ,\
     HID_LOGICAL_MAX  ( 0x7f                                   ) ,\
     HID_REPORT_COUNT ( 6                                      ) ,\
@@ -287,6 +278,15 @@ TU_ATTR_WEAK bool tud_hid_set_idle_cb(uint8_t idle_rate);
     HID_PHYSICAL_MAX_N ( 315, 2                               ) ,\
     HID_REPORT_COUNT ( 1                                      ) ,\
     HID_REPORT_SIZE  ( 8                                      ) ,\
+    HID_INPUT        ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE ) ,\
+    /* 16 bit Button Map */ \
+    HID_USAGE_PAGE   ( HID_USAGE_PAGE_BUTTON                  ) ,\
+    HID_USAGE_MIN    ( 1                                      ) ,\
+    HID_USAGE_MAX    ( 16                                     ) ,\
+    HID_LOGICAL_MIN  ( 0                                      ) ,\
+    HID_LOGICAL_MAX  ( 1                                      ) ,\
+    HID_REPORT_COUNT ( 16                                     ) ,\
+    HID_REPORT_SIZE  ( 1                                      ) ,\
     HID_INPUT        ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE ) ,\
   HID_COLLECTION_END \
 

--- a/tinyusb/src/class/hid/hid_device.h
+++ b/tinyusb/src/class/hid/hid_device.h
@@ -249,7 +249,7 @@ TU_ATTR_WEAK bool tud_hid_set_idle_cb(uint8_t idle_rate);
 
 // Gamepad Report Descriptor Template
 // with 16 buttons, 2 joysticks and 1 hat/dpad with following layout
-// | Button Map (2 bytes) |  X | Y | Z | Rz (1 byte each) | hat/DPAD (1 byte)
+// | Button Map (2 bytes) |  X | Y | Z | Rx | Ry | Rz (1 byte each) | hat/DPAD (1 byte)
 #define TUD_HID_REPORT_DESC_GAMEPAD(...) \
   HID_USAGE_PAGE ( HID_USAGE_PAGE_DESKTOP     )                 ,\
   HID_USAGE      ( HID_USAGE_DESKTOP_GAMEPAD  )                 ,\
@@ -265,21 +265,23 @@ TU_ATTR_WEAK bool tud_hid_set_idle_cb(uint8_t idle_rate);
     HID_REPORT_COUNT ( 16                                     ) ,\
     HID_REPORT_SIZE  ( 1                                      ) ,\
     HID_INPUT        ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE ) ,\
-    /* 8 bit X, Y, Z, Rz (min -127, max 127 ) */ \
+    /* 8 bit X, Y, Z, Rx, Ry, Rz (min -127, max 127 ) */ \
     HID_USAGE_PAGE   ( HID_USAGE_PAGE_DESKTOP                 ) ,\
     HID_USAGE        ( HID_USAGE_DESKTOP_X                    ) ,\
     HID_USAGE        ( HID_USAGE_DESKTOP_Y                    ) ,\
     HID_USAGE        ( HID_USAGE_DESKTOP_Z                    ) ,\
+    HID_USAGE        ( HID_USAGE_DESKTOP_RX                   ) ,\
+    HID_USAGE        ( HID_USAGE_DESKTOP_RY                   ) ,\
     HID_USAGE        ( HID_USAGE_DESKTOP_RZ                   ) ,\
     HID_LOGICAL_MIN  ( 0x81                                   ) ,\
     HID_LOGICAL_MAX  ( 0x7f                                   ) ,\
-    HID_REPORT_COUNT ( 4                                      ) ,\
+    HID_REPORT_COUNT ( 6                                      ) ,\
     HID_REPORT_SIZE  ( 8                                      ) ,\
     HID_INPUT        ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE ) ,\
     /* 8 bit Hat Button Map  */ \
     HID_USAGE_PAGE   ( HID_USAGE_PAGE_DESKTOP                 ) ,\
     HID_USAGE        ( HID_USAGE_DESKTOP_HAT_SWITCH           ) ,\
-    HID_LOGICAL_MIN  ( 0                                      ) ,\
+    HID_LOGICAL_MIN  ( 1                                      ) ,\
     HID_LOGICAL_MAX  ( 8                                      ) ,\
     HID_PHYSICAL_MIN ( 0                                      ) ,\
     HID_PHYSICAL_MAX_N ( 315, 2                               ) ,\

--- a/tinyusb/src/class/hid/hid_device.h
+++ b/tinyusb/src/class/hid/hid_device.h
@@ -248,12 +248,12 @@ TU_ATTR_WEAK bool tud_hid_set_idle_cb(uint8_t idle_rate);
   HID_COLLECTION_END \
 
 // Gamepad Report Descriptor Template
-// with 16 buttons and 2 joysticks with following layout
-// | Button Map (2 bytes) |  X | Y | Z | Rz
+// with 16 buttons, 2 joysticks and 1 hat/dpad with following layout
+// | Button Map (2 bytes) |  X | Y | Z | Rz (1 byte each) | hat/DPAD (1 byte)
 #define TUD_HID_REPORT_DESC_GAMEPAD(...) \
-  HID_USAGE_PAGE ( HID_USAGE_PAGE_DESKTOP     )        ,\
-  HID_USAGE      ( HID_USAGE_DESKTOP_GAMEPAD  )        ,\
-  HID_COLLECTION ( HID_COLLECTION_APPLICATION )        ,\
+  HID_USAGE_PAGE ( HID_USAGE_PAGE_DESKTOP     )                 ,\
+  HID_USAGE      ( HID_USAGE_DESKTOP_GAMEPAD  )                 ,\
+  HID_COLLECTION ( HID_COLLECTION_APPLICATION )                 ,\
     /* Report ID if any */\
     __VA_ARGS__ \
     /* 16 bit Button Map */ \
@@ -265,15 +265,25 @@ TU_ATTR_WEAK bool tud_hid_set_idle_cb(uint8_t idle_rate);
     HID_REPORT_COUNT ( 16                                     ) ,\
     HID_REPORT_SIZE  ( 1                                      ) ,\
     HID_INPUT        ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE ) ,\
-    /* X, Y, Z, Rz (min -127, max 127 ) */ \
+    /* 8 bit X, Y, Z, Rz (min -127, max 127 ) */ \
     HID_USAGE_PAGE   ( HID_USAGE_PAGE_DESKTOP                 ) ,\
-    HID_LOGICAL_MIN  ( 0x81                                   ) ,\
-    HID_LOGICAL_MAX  ( 0x7f                                   ) ,\
     HID_USAGE        ( HID_USAGE_DESKTOP_X                    ) ,\
     HID_USAGE        ( HID_USAGE_DESKTOP_Y                    ) ,\
     HID_USAGE        ( HID_USAGE_DESKTOP_Z                    ) ,\
     HID_USAGE        ( HID_USAGE_DESKTOP_RZ                   ) ,\
+    HID_LOGICAL_MIN  ( 0x81                                   ) ,\
+    HID_LOGICAL_MAX  ( 0x7f                                   ) ,\
     HID_REPORT_COUNT ( 4                                      ) ,\
+    HID_REPORT_SIZE  ( 8                                      ) ,\
+    HID_INPUT        ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE ) ,\
+    /* 8 bit Hat Button Map  */ \
+    HID_USAGE_PAGE   ( HID_USAGE_PAGE_DESKTOP                 ) ,\
+    HID_USAGE        ( HID_USAGE_DESKTOP_HAT_SWITCH           ) ,\
+    HID_LOGICAL_MIN  ( 1                                      ) ,\
+    HID_LOGICAL_MAX  ( 8                                      ) ,\
+    HID_PHYSICAL_MIN ( 0                                      ) ,\
+    HID_PHYSICAL_MAX ( 315                                    ) ,\
+    HID_REPORT_COUNT ( 1                                      ) ,\
     HID_REPORT_SIZE  ( 8                                      ) ,\
     HID_INPUT        ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE ) ,\
   HID_COLLECTION_END \

--- a/tinyusb/src/class/hid/hid_device.h
+++ b/tinyusb/src/class/hid/hid_device.h
@@ -249,36 +249,27 @@ TU_ATTR_WEAK bool tud_hid_set_idle_cb(uint8_t idle_rate);
 
 // Gamepad Report Descriptor Template
 // with 16 buttons, 2 joysticks and 1 hat/dpad with following layout
-// | Button Map (2 bytes) |  X | Y | Z | Rx | Ry | Rz (1 byte each) | hat/DPAD (1 byte)
+// | X | Y | Z | Rz | Rx | Ry (1 byte each) | hat/DPAD (1 byte) | Button Map (2 bytes) |
 #define TUD_HID_REPORT_DESC_GAMEPAD(...) \
   HID_USAGE_PAGE ( HID_USAGE_PAGE_DESKTOP     )                 ,\
   HID_USAGE      ( HID_USAGE_DESKTOP_GAMEPAD  )                 ,\
   HID_COLLECTION ( HID_COLLECTION_APPLICATION )                 ,\
     /* Report ID if any */\
     __VA_ARGS__ \
-    /* 16 bit Button Map */ \
-    HID_USAGE_PAGE   ( HID_USAGE_PAGE_BUTTON                  ) ,\
-    HID_USAGE_MIN    ( 1                                      ) ,\
-    HID_USAGE_MAX    ( 16                                     ) ,\
-    HID_LOGICAL_MIN  ( 0                                      ) ,\
-    HID_LOGICAL_MAX  ( 1                                      ) ,\
-    HID_REPORT_COUNT ( 16                                     ) ,\
-    HID_REPORT_SIZE  ( 1                                      ) ,\
-    HID_INPUT        ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE ) ,\
-    /* 8 bit X, Y, Z, Rx, Ry, Rz (min -127, max 127 ) */ \
+    /* 8 bit X, Y, Z, Rz, Rx, Ry (min -127, max 127 ) */ \
     HID_USAGE_PAGE   ( HID_USAGE_PAGE_DESKTOP                 ) ,\
     HID_USAGE        ( HID_USAGE_DESKTOP_X                    ) ,\
     HID_USAGE        ( HID_USAGE_DESKTOP_Y                    ) ,\
     HID_USAGE        ( HID_USAGE_DESKTOP_Z                    ) ,\
+    HID_USAGE        ( HID_USAGE_DESKTOP_RZ                   ) ,\
     HID_USAGE        ( HID_USAGE_DESKTOP_RX                   ) ,\
     HID_USAGE        ( HID_USAGE_DESKTOP_RY                   ) ,\
-    HID_USAGE        ( HID_USAGE_DESKTOP_RZ                   ) ,\
     HID_LOGICAL_MIN  ( 0x81                                   ) ,\
     HID_LOGICAL_MAX  ( 0x7f                                   ) ,\
     HID_REPORT_COUNT ( 6                                      ) ,\
     HID_REPORT_SIZE  ( 8                                      ) ,\
     HID_INPUT        ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE ) ,\
-    /* 8 bit Hat Button Map  */ \
+    /* 8 bit DPad/Hat Button Map  */ \
     HID_USAGE_PAGE   ( HID_USAGE_PAGE_DESKTOP                 ) ,\
     HID_USAGE        ( HID_USAGE_DESKTOP_HAT_SWITCH           ) ,\
     HID_LOGICAL_MIN  ( 1                                      ) ,\
@@ -287,6 +278,15 @@ TU_ATTR_WEAK bool tud_hid_set_idle_cb(uint8_t idle_rate);
     HID_PHYSICAL_MAX_N ( 315, 2                               ) ,\
     HID_REPORT_COUNT ( 1                                      ) ,\
     HID_REPORT_SIZE  ( 8                                      ) ,\
+    HID_INPUT        ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE ) ,\
+    /* 16 bit Button Map */ \
+    HID_USAGE_PAGE   ( HID_USAGE_PAGE_BUTTON                  ) ,\
+    HID_USAGE_MIN    ( 1                                      ) ,\
+    HID_USAGE_MAX    ( 16                                     ) ,\
+    HID_LOGICAL_MIN  ( 0                                      ) ,\
+    HID_LOGICAL_MAX  ( 1                                      ) ,\
+    HID_REPORT_COUNT ( 16                                     ) ,\
+    HID_REPORT_SIZE  ( 1                                      ) ,\
     HID_INPUT        ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE ) ,\
   HID_COLLECTION_END \
 


### PR DESCRIPTION
Changes needed to add basic gamepad support. See PR #622 from  `adafruit/Adafruit_nRF52_Arduino` repo.