### PR TITLE
Fix many unused parameter compilation warnings

### DIFF
--- a/Adafruit_USBD_Device.cpp
+++ b/Adafruit_USBD_Device.cpp
@@ -294,16 +294,57 @@ uint16_t const* tud_descriptor_string_cb(uint8_t index, uint16_t langid)
 
 // HID
 TU_ATTR_WEAK uint8_t const * tud_hid_descriptor_report_cb(void) { return NULL; }
-TU_ATTR_WEAK uint16_t tud_hid_get_report_cb(uint8_t report_id, hid_report_type_t report_type, uint8_t* buffer, uint16_t reqlen) { return 0; }
-TU_ATTR_WEAK void tud_hid_set_report_cb(uint8_t report_id, hid_report_type_t report_type, uint8_t const* buffer, uint16_t bufsize) { }
-
+TU_ATTR_WEAK uint16_t tud_hid_get_report_cb(uint8_t report_id, hid_report_type_t report_type, uint8_t* buffer, uint16_t reqlen) {
+  (void)report_id;
+  (void)report_type;
+  (void)buffer;
+  (void)reqlen;
+  return 0;
+}
+TU_ATTR_WEAK void tud_hid_set_report_cb(uint8_t report_id, hid_report_type_t report_type, uint8_t const* buffer, uint16_t bufsize) {
+  (void)report_id;
+  (void)report_type;
+  (void)buffer;
+  (void)bufsize;
+}
 // MSC
-TU_ATTR_WEAK int32_t tud_msc_read10_cb (uint8_t lun, uint32_t lba, uint32_t offset, void* buffer, uint32_t bufsize) { return -1; }
-TU_ATTR_WEAK int32_t tud_msc_write10_cb (uint8_t lun, uint32_t lba, uint32_t offset, uint8_t* buffer, uint32_t bufsize) { return -1; }
-TU_ATTR_WEAK void tud_msc_inquiry_cb(uint8_t lun, uint8_t vendor_id[8], uint8_t product_id[16], uint8_t product_rev[4]) {}
-TU_ATTR_WEAK bool tud_msc_test_unit_ready_cb(uint8_t lun) { return false; }
-TU_ATTR_WEAK void tud_msc_capacity_cb(uint8_t lun, uint32_t* block_count, uint16_t* block_size) { }
-TU_ATTR_WEAK int32_t tud_msc_scsi_cb (uint8_t lun, uint8_t const scsi_cmd[16], void* buffer, uint16_t bufsize) { return -1; }
+TU_ATTR_WEAK int32_t tud_msc_read10_cb (uint8_t lun, uint32_t lba, uint32_t offset, void* buffer, uint32_t bufsize) {
+  (void)lun;
+  (void)lba;
+  (void)offset;
+  (void)buffer;
+  (void)bufsize;
+  return -1;
+}
+TU_ATTR_WEAK int32_t tud_msc_write10_cb (uint8_t lun, uint32_t lba, uint32_t offset, uint8_t* buffer, uint32_t bufsize) {
+  (void)lun;
+  (void)lba;
+  (void)offset;
+  (void)buffer;
+  (void)bufsize;
+  return -1;
+}
+TU_ATTR_WEAK void tud_msc_inquiry_cb(uint8_t lun, uint8_t vendor_id[8], uint8_t product_id[16], uint8_t product_rev[4]) {
+  (void)lun;
+  (void)vendor_id;
+  (void)product_id;
+  (void)product_rev;
+}
+TU_ATTR_WEAK bool tud_msc_test_unit_ready_cb(uint8_t lun) {
+  return false;
+}
+TU_ATTR_WEAK void tud_msc_capacity_cb(uint8_t lun, uint32_t* block_count, uint16_t* block_size) {
+  (void)lun;
+  (void)block_count;
+  (void)block_size;
+}
+TU_ATTR_WEAK int32_t tud_msc_scsi_cb (uint8_t lun, uint8_t const scsi_cmd[16], void* buffer, uint16_t bufsize) {
+  (void)lun;
+  (void)scsi_cmd;
+  (void)buffer;
+  (void)bufsize;
+  return -1;
+}
 
 } // extern C
 

--- a/Adafruit_USBD_Device.cpp
+++ b/Adafruit_USBD_Device.cpp
@@ -331,6 +331,7 @@ TU_ATTR_WEAK void tud_msc_inquiry_cb(uint8_t lun, uint8_t vendor_id[8], uint8_t 
   (void)product_rev;
 }
 TU_ATTR_WEAK bool tud_msc_test_unit_ready_cb(uint8_t lun) {
+  (void)lun;
   return false;
 }
 TU_ATTR_WEAK void tud_msc_capacity_cb(uint8_t lun, uint32_t* block_count, uint16_t* block_size) {


### PR DESCRIPTION
No effective code change, but cleans up many compiler warnings.

```
...\cores\arduino\TinyUSB\Adafruit_TinyUSB_ArduinoCore\Adafruit_USBD_Device.cpp:
      Line 297 Char 53
      In function 'uint16_t tud_hid_get_report_cb(uint8_t, hid_report_type_t, uint8_t*, uint16_t)':
      warning: unused parameter 'report_id' [-Wunused-parameter]
  297 | TU_ATTR_WEAK uint16_t tud_hid_get_report_cb(uint8_t report_id, hid_report_type_t report_type, uint8_t* buffer, uint16_t reqlen) { return 0; }
      |                                             ~~~~~~~~^~~~~~~~~
...\cores\arduino\TinyUSB\Adafruit_TinyUSB_ArduinoCore\Adafruit_USBD_Device.cpp:
      Line 297 Char 82
      warning: unused parameter 'report_type' [-Wunused-parameter]
  297 | TU_ATTR_WEAK uint16_t tud_hid_get_report_cb(uint8_t report_id, hid_report_type_t report_type, uint8_t* buffer, uint16_t reqlen) { return 0; }
      |                                                                ~~~~~~~~~~~~~~~~~~^~~~~~~~~~~
...\cores\arduino\TinyUSB\Adafruit_TinyUSB_ArduinoCore\Adafruit_USBD_Device.cpp:
      Line 297 Char 104
      warning: unused parameter 'buffer' [-Wunused-parameter]
  297 | TU_ATTR_WEAK uint16_t tud_hid_get_report_cb(uint8_t report_id, hid_report_type_t report_type, uint8_t* buffer, uint16_t reqlen) { return 0; }
      |                                                                                               ~~~~~~~~~^~~~~~
...\cores\arduino\TinyUSB\Adafruit_TinyUSB_ArduinoCore\Adafruit_USBD_Device.cpp:
      Line 297 Char 121
      warning: unused parameter 'reqlen' [-Wunused-parameter]
  297 | TU_ATTR_WEAK uint16_t tud_hid_get_report_cb(uint8_t report_id, hid_report_type_t report_type, uint8_t* buffer, uint16_t reqlen) { return 0; }
      |                                                                                                                ~~~~~~~~~^~~~~~
...\cores\arduino\TinyUSB\Adafruit_TinyUSB_ArduinoCore\Adafruit_USBD_Device.cpp:
      Line 298 Char 49
      In function 'void tud_hid_set_report_cb(uint8_t, hid_report_type_t, const uint8_t*, uint16_t)':
      warning: unused parameter 'report_id' [-Wunused-parameter]
  298 | TU_ATTR_WEAK void tud_hid_set_report_cb(uint8_t report_id, hid_report_type_t report_type, uint8_t const* buffer, uint16_t bufsize) { }
      |                                         ~~~~~~~~^~~~~~~~~
...\cores\arduino\TinyUSB\Adafruit_TinyUSB_ArduinoCore\Adafruit_USBD_Device.cpp:
      Line 298 Char 78
      warning: unused parameter 'report_type' [-Wunused-parameter]
  298 | TU_ATTR_WEAK void tud_hid_set_report_cb(uint8_t report_id, hid_report_type_t report_type, uint8_t const* buffer, uint16_t bufsize) { }
      |                                                            ~~~~~~~~~~~~~~~~~~^~~~~~~~~~~
...\cores\arduino\TinyUSB\Adafruit_TinyUSB_ArduinoCore\Adafruit_USBD_Device.cpp:
      Line 298 Char 106
      warning: unused parameter 'buffer' [-Wunused-parameter]
  298 | TU_ATTR_WEAK void tud_hid_set_report_cb(uint8_t report_id, hid_report_type_t report_type, uint8_t const* buffer, uint16_t bufsize) { }
      |                                                                                           ~~~~~~~~~~~~~~~^~~~~~
...\cores\arduino\TinyUSB\Adafruit_TinyUSB_ArduinoCore\Adafruit_USBD_Device.cpp:
      Line 298 Char 123
      warning: unused parameter 'bufsize' [-Wunused-parameter]
  298 | TU_ATTR_WEAK void tud_hid_set_report_cb(uint8_t report_id, hid_report_type_t report_type, uint8_t const* buffer, uint16_t bufsize) { }
      |                                                                                                                  ~~~~~~~~~^~~~~~~
...\cores\arduino\TinyUSB\Adafruit_TinyUSB_ArduinoCore\Adafruit_USBD_Device.cpp:
      Line 301 Char 49
      In function 'int32_t tud_msc_read10_cb(uint8_t, uint32_t, uint32_t, void*, uint32_t)':
      warning: unused parameter 'lun' [-Wunused-parameter]
  301 | TU_ATTR_WEAK int32_t tud_msc_read10_cb (uint8_t lun, uint32_t lba, uint32_t offset, void* buffer, uint32_t bufsize) { return -1; }
      |                                         ~~~~~~~~^~~
...\cores\arduino\TinyUSB\Adafruit_TinyUSB_ArduinoCore\Adafruit_USBD_Device.cpp:
      Line 301 Char 63
      warning: unused parameter 'lba' [-Wunused-parameter]
  301 | TU_ATTR_WEAK int32_t tud_msc_read10_cb (uint8_t lun, uint32_t lba, uint32_t offset, void* buffer, uint32_t bufsize) { return -1; }
      |                                                      ~~~~~~~~~^~~
...\cores\arduino\TinyUSB\Adafruit_TinyUSB_ArduinoCore\Adafruit_USBD_Device.cpp:
      Line 301 Char 77
      warning: unused parameter 'offset' [-Wunused-parameter]
  301 | TU_ATTR_WEAK int32_t tud_msc_read10_cb (uint8_t lun, uint32_t lba, uint32_t offset, void* buffer, uint32_t bufsize) { return -1; }
      |                                                                    ~~~~~~~~~^~~~~~
...\cores\arduino\TinyUSB\Adafruit_TinyUSB_ArduinoCore\Adafruit_USBD_Device.cpp:
      Line 301 Char 91
      warning: unused parameter 'buffer' [-Wunused-parameter]
  301 | TU_ATTR_WEAK int32_t tud_msc_read10_cb (uint8_t lun, uint32_t lba, uint32_t offset, void* buffer, uint32_t bufsize) { return -1; }
      |                                                                                     ~~~~~~^~~~~~
...\cores\arduino\TinyUSB\Adafruit_TinyUSB_ArduinoCore\Adafruit_USBD_Device.cpp:
      Line 301 Char 108
      warning: unused parameter 'bufsize' [-Wunused-parameter]
  301 | TU_ATTR_WEAK int32_t tud_msc_read10_cb (uint8_t lun, uint32_t lba, uint32_t offset, void* buffer, uint32_t bufsize) { return -1; }
      |                                                                                                   ~~~~~~~~~^~~~~~~
...\cores\arduino\TinyUSB\Adafruit_TinyUSB_ArduinoCore\Adafruit_USBD_Device.cpp:
      Line 302 Char 50
      In function 'int32_t tud_msc_write10_cb(uint8_t, uint32_t, uint32_t, uint8_t*, uint32_t)':
      warning: unused parameter 'lun' [-Wunused-parameter]
  302 | TU_ATTR_WEAK int32_t tud_msc_write10_cb (uint8_t lun, uint32_t lba, uint32_t offset, uint8_t* buffer, uint32_t bufsize) { return -1; }
      |                                          ~~~~~~~~^~~
...\cores\arduino\TinyUSB\Adafruit_TinyUSB_ArduinoCore\Adafruit_USBD_Device.cpp:
      Line 302 Char 64
      warning: unused parameter 'lba' [-Wunused-parameter]
  302 | TU_ATTR_WEAK int32_t tud_msc_write10_cb (uint8_t lun, uint32_t lba, uint32_t offset, uint8_t* buffer, uint32_t bufsize) { return -1; }
      |                                                       ~~~~~~~~~^~~
...\cores\arduino\TinyUSB\Adafruit_TinyUSB_ArduinoCore\Adafruit_USBD_Device.cpp:
      Line 302 Char 78
      warning: unused parameter 'offset' [-Wunused-parameter]
  302 | TU_ATTR_WEAK int32_t tud_msc_write10_cb (uint8_t lun, uint32_t lba, uint32_t offset, uint8_t* buffer, uint32_t bufsize) { return -1; }
      |                                                                     ~~~~~~~~~^~~~~~
...\cores\arduino\TinyUSB\Adafruit_TinyUSB_ArduinoCore\Adafruit_USBD_Device.cpp:
      Line 302 Char 95
      warning: unused parameter 'buffer' [-Wunused-parameter]
  302 | TU_ATTR_WEAK int32_t tud_msc_write10_cb (uint8_t lun, uint32_t lba, uint32_t offset, uint8_t* buffer, uint32_t bufsize) { return -1; }
      |                                                                                      ~~~~~~~~~^~~~~~
...\cores\arduino\TinyUSB\Adafruit_TinyUSB_ArduinoCore\Adafruit_USBD_Device.cpp:
      Line 302 Char 112
      warning: unused parameter 'bufsize' [-Wunused-parameter]
  302 | TU_ATTR_WEAK int32_t tud_msc_write10_cb (uint8_t lun, uint32_t lba, uint32_t offset, uint8_t* buffer, uint32_t bufsize) { return -1; }
      |                                                                                                       ~~~~~~~~~^~~~~~~
...\cores\arduino\TinyUSB\Adafruit_TinyUSB_ArduinoCore\Adafruit_USBD_Device.cpp:
      Line 303 Char 46
      In function 'void tud_msc_inquiry_cb(uint8_t, uint8_t*, uint8_t*, uint8_t*)':
      warning: unused parameter 'lun' [-Wunused-parameter]
  303 | TU_ATTR_WEAK void tud_msc_inquiry_cb(uint8_t lun, uint8_t vendor_id[8], uint8_t product_id[16], uint8_t product_rev[4]) {}
      |                                      ~~~~~~~~^~~
...\cores\arduino\TinyUSB\Adafruit_TinyUSB_ArduinoCore\Adafruit_USBD_Device.cpp:
      Line 303 Char 59
      warning: unused parameter 'vendor_id' [-Wunused-parameter]
  303 | TU_ATTR_WEAK void tud_msc_inquiry_cb(uint8_t lun, uint8_t vendor_id[8], uint8_t product_id[16], uint8_t product_rev[4]) {}
      |                                                   ~~~~~~~~^~~~~~~~~~~~
...\cores\arduino\TinyUSB\Adafruit_TinyUSB_ArduinoCore\Adafruit_USBD_Device.cpp:
      Line 303 Char 81
      warning: unused parameter 'product_id' [-Wunused-parameter]
  303 | TU_ATTR_WEAK void tud_msc_inquiry_cb(uint8_t lun, uint8_t vendor_id[8], uint8_t product_id[16], uint8_t product_rev[4]) {}
      |                                                                         ~~~~~~~~^~~~~~~~~~~~~~
...\cores\arduino\TinyUSB\Adafruit_TinyUSB_ArduinoCore\Adafruit_USBD_Device.cpp:
      Line 303 Char 105
      warning: unused parameter 'product_rev' [-Wunused-parameter]
  303 | TU_ATTR_WEAK void tud_msc_inquiry_cb(uint8_t lun, uint8_t vendor_id[8], uint8_t product_id[16], uint8_t product_rev[4]) {}
      |                                                                                                 ~~~~~~~~^~~~~~~~~~~~~~
...\cores\arduino\TinyUSB\Adafruit_TinyUSB_ArduinoCore\Adafruit_USBD_Device.cpp:
      Line 304 Char 54
      In function 'bool tud_msc_test_unit_ready_cb(uint8_t)':
      warning: unused parameter 'lun' [-Wunused-parameter]
  304 | TU_ATTR_WEAK bool tud_msc_test_unit_ready_cb(uint8_t lun) { return false; }
      |                                              ~~~~~~~~^~~
...\cores\arduino\TinyUSB\Adafruit_TinyUSB_ArduinoCore\Adafruit_USBD_Device.cpp:
      Line 305 Char 47
      In function 'void tud_msc_capacity_cb(uint8_t, uint32_t*, uint16_t*)':
      warning: unused parameter 'lun' [-Wunused-parameter]
  305 | TU_ATTR_WEAK void tud_msc_capacity_cb(uint8_t lun, uint32_t* block_count, uint16_t* block_size) { }
      |                                       ~~~~~~~~^~~
...\cores\arduino\TinyUSB\Adafruit_TinyUSB_ArduinoCore\Adafruit_USBD_Device.cpp:
      Line 305 Char 62
      warning: unused parameter 'block_count' [-Wunused-parameter]
  305 | TU_ATTR_WEAK void tud_msc_capacity_cb(uint8_t lun, uint32_t* block_count, uint16_t* block_size) { }
      |                                                    ~~~~~~~~~~^~~~~~~~~~~
...\cores\arduino\TinyUSB\Adafruit_TinyUSB_ArduinoCore\Adafruit_USBD_Device.cpp:
      Line 305 Char 85
      warning: unused parameter 'block_size' [-Wunused-parameter]
  305 | TU_ATTR_WEAK void tud_msc_capacity_cb(uint8_t lun, uint32_t* block_count, uint16_t* block_size) { }
      |                                                                           ~~~~~~~~~~^~~~~~~~~~
...\cores\arduino\TinyUSB\Adafruit_TinyUSB_ArduinoCore\Adafruit_USBD_Device.cpp:
      Line 306 Char 47
      In function 'int32_t tud_msc_scsi_cb(uint8_t, const uint8_t*, void*, uint16_t)':
      warning: unused parameter 'lun' [-Wunused-parameter]
  306 | TU_ATTR_WEAK int32_t tud_msc_scsi_cb (uint8_t lun, uint8_t const scsi_cmd[16], void* buffer, uint16_t bufsize) { return -1; }
      |                                       ~~~~~~~~^~~
...\cores\arduino\TinyUSB\Adafruit_TinyUSB_ArduinoCore\Adafruit_USBD_Device.cpp:
      Line 306 Char 66
      warning: unused parameter 'scsi_cmd' [-Wunused-parameter]
  306 | TU_ATTR_WEAK int32_t tud_msc_scsi_cb (uint8_t lun, uint8_t const scsi_cmd[16], void* buffer, uint16_t bufsize) { return -1; }
      |                                                    ~~~~~~~~~~~~~~^~~~~~~~~~~~
...\cores\arduino\TinyUSB\Adafruit_TinyUSB_ArduinoCore\Adafruit_USBD_Device.cpp:
      Line 306 Char 86
      warning: unused parameter 'buffer' [-Wunused-parameter]
  306 | TU_ATTR_WEAK int32_t tud_msc_scsi_cb (uint8_t lun, uint8_t const scsi_cmd[16], void* buffer, uint16_t bufsize) { return -1; }
      |                                                                                ~~~~~~^~~~~~
...\cores\arduino\TinyUSB\Adafruit_TinyUSB_ArduinoCore\Adafruit_USBD_Device.cpp:
      Line 306 Char 103
      warning: unused parameter 'bufsize' [-Wunused-parameter]
  306 | TU_ATTR_WEAK int32_t tud_msc_scsi_cb (uint8_t lun, uint8_t const scsi_cmd[16], void* buffer, uint16_t bufsize) { return -1; }
      |                                                                                              ~~~~~~~~~^~~~~~~
```
